### PR TITLE
Fix wallet connection and page refresh issues

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import About from './pages/About';
 import RoleSelect from './pages/RoleSelect';
 import Register from './pages/Register';
 import ClientInvoiceLookup from './pages/ClientInvoiceLookup';
+import { useWalletRestore } from './hooks/useWalletRestore';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -32,6 +33,8 @@ function LegacyInvoiceRedirect() {
 }
 
 export default function App() {
+  useWalletRestore();
+
   return (
     <QueryClientProvider client={queryClient}>
       <Toaster

--- a/frontend/src/hooks/useWalletRestore.ts
+++ b/frontend/src/hooks/useWalletRestore.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+import { useWalletStore } from '../store/walletStore';
+
+/**
+ * Hook to restore wallet connection on app initialization
+ * Only runs once when the app first loads
+ */
+export function useWalletRestore() {
+  const restoreConnection = useWalletStore((state) => state.restoreConnection);
+  const hasRestoredRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasRestoredRef.current) {
+      hasRestoredRef.current = true;
+      restoreConnection();
+    }
+  }, [restoreConnection]);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
       },
     },
   },
+  preview: {
+    port: 4173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
   build: {
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
Fixes #4

## Changes

- Add finally block to wallet `connect()` to ensure `isConnecting` is always reset
- Add persist middleware to store wallet state (`publicKey`, `connected`) in localStorage  
- Add `restoreConnection()` function to verify Freighter availability and account match on app initialization
- Add `useWalletRestore` hook to call `restoreConnection` when app loads
- Add preview config with API proxy to `vite.config.ts`

## Bugs Fixed

1. **Connect Wallet button stuck on "Connecting..."**: When user cancels the Freighter popup, the button now properly returns to "Connect Wallet" state
2. **Wallet connection not persisting on page refresh**: After connecting wallet and refreshing the page, the wallet connection is now maintained

## Testing

Tested locally on preview server (port 4173) with clean builds.