### PR TITLE
Fix Privy sign-out not syncing outside /login

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4576,9 +4576,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4596,9 +4593,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4616,9 +4610,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4636,9 +4627,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/src/components/Auth/PrivyLogin.tsx
+++ b/frontend/src/components/Auth/PrivyLogin.tsx
@@ -1,58 +1,12 @@
-import { useEffect, useRef } from 'react';
 import { usePrivy } from '@privy-io/react-auth';
-import { useCreateWallet, useSignRawHash } from '@privy-io/react-auth/extended-chains';
-import { useWalletStore } from '../../store/walletStore';
-import { buildPrivySigner } from '../../services/privy';
 
-function getStellarAddress(user: any): string | null {
-  const account = user?.linkedAccounts?.find(
-    (a: any) => a.type === 'wallet' && a.chainType === 'stellar'
-  );
-  return account?.address ?? null;
-}
-
+/**
+ * Sign in / sign out button. The actual wallet-store sync lives in
+ * PrivyWalletBridge (mounted once, globally) so it keeps working regardless
+ * of which page is rendered — see that file for why.
+ */
 export default function PrivyLogin({ variant = 'compact' }: { variant?: 'compact' | 'large' }) {
-  const { authenticated, login, logout, ready, user, getAccessToken } = usePrivy();
-  const { createWallet } = useCreateWallet();
-  const { signRawHash } = useSignRawHash();
-
-  const { setExternalWallet, clearExternalWallet, setPrivyLoading, connected, setPrivyGetToken } = useWalletStore();
-
-  const signRef = useRef(signRawHash);
-  useEffect(() => { signRef.current = signRawHash; }, [signRawHash]);
-
-  const getAccessTokenRef = useRef(getAccessToken);
-  useEffect(() => { getAccessTokenRef.current = getAccessToken; }, [getAccessToken]);
-
-  const stellarAddress = getStellarAddress(user);
-
-  // Signal to Layout that Privy is authenticated but wallet isn't bridged yet
-  useEffect(() => {
-    if (authenticated && !stellarAddress) {
-      setPrivyLoading(true);
-      createWallet({ chainType: 'stellar' } as any).catch(() => setPrivyLoading(false));
-    }
-  }, [authenticated, stellarAddress, createWallet, setPrivyLoading]);
-
-  // Register/unregister the Privy token getter (used by auth.ts instead of nonce signing)
-  useEffect(() => {
-    if (authenticated) {
-      const getter = () => getAccessTokenRef.current();
-      setPrivyGetToken(getter);
-    } else {
-      setPrivyGetToken(null);
-    }
-  }, [authenticated, setPrivyGetToken]);
-
-  // Bridge Stellar wallet → walletStore once address is available
-  useEffect(() => {
-    if (authenticated && stellarAddress) {
-      const signer = buildPrivySigner(stellarAddress, (input) => signRef.current(input));
-      setExternalWallet(stellarAddress, signer);
-    } else if (!authenticated && connected) {
-      clearExternalWallet();
-    }
-  }, [authenticated, stellarAddress, setExternalWallet, clearExternalWallet, connected]);
+  const { authenticated, login, logout, ready } = usePrivy();
 
   if (!ready) return null;
 

--- a/frontend/src/components/Auth/PrivyWalletBridge.tsx
+++ b/frontend/src/components/Auth/PrivyWalletBridge.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+import { usePrivy } from '@privy-io/react-auth';
+import { useCreateWallet, useSignRawHash } from '@privy-io/react-auth/extended-chains';
+import { useWalletStore } from '../../store/walletStore';
+import { buildPrivySigner } from '../../services/privy';
+
+function getStellarAddress(user: any): string | null {
+  const account = user?.linkedAccounts?.find(
+    (a: any) => a.type === 'wallet' && a.chainType === 'stellar'
+  );
+  return account?.address ?? null;
+}
+
+/**
+ * Keeps the wallet store in sync with Privy's auth state for the lifetime of
+ * the app — not just while a login button happens to be mounted. Without
+ * this living somewhere route-independent, logging out from a dashboard page
+ * (where PrivyLogin isn't rendered) flips Privy's `authenticated` to false
+ * but never reaches the wallet store, so `connected` stays true and the UI
+ * never reflects the sign-out.
+ */
+export default function PrivyWalletBridge() {
+  const { authenticated, user, getAccessToken } = usePrivy();
+  const { createWallet } = useCreateWallet();
+  const { signRawHash } = useSignRawHash();
+
+  const { setExternalWallet, clearExternalWallet, setPrivyLoading, connected, setPrivyGetToken } = useWalletStore();
+
+  const signRef = useRef(signRawHash);
+  useEffect(() => { signRef.current = signRawHash; }, [signRawHash]);
+
+  const getAccessTokenRef = useRef(getAccessToken);
+  useEffect(() => { getAccessTokenRef.current = getAccessToken; }, [getAccessToken]);
+
+  const stellarAddress = getStellarAddress(user);
+
+  // Signal to Layout that Privy is authenticated but wallet isn't bridged yet
+  useEffect(() => {
+    if (authenticated && !stellarAddress) {
+      setPrivyLoading(true);
+      createWallet({ chainType: 'stellar' } as any).catch(() => setPrivyLoading(false));
+    }
+  }, [authenticated, stellarAddress, createWallet, setPrivyLoading]);
+
+  // Register/unregister the Privy token getter (used by auth.ts instead of nonce signing)
+  useEffect(() => {
+    if (authenticated) {
+      const getter = () => getAccessTokenRef.current();
+      setPrivyGetToken(getter);
+    } else {
+      setPrivyGetToken(null);
+    }
+  }, [authenticated, setPrivyGetToken]);
+
+  // Bridge Stellar wallet <-> walletStore, both ways: connect once the
+  // address is available, and clear it the moment Privy signs out.
+  useEffect(() => {
+    if (authenticated && stellarAddress) {
+      const signer = buildPrivySigner(stellarAddress, (input) => signRef.current(input));
+      setExternalWallet(stellarAddress, signer);
+    } else if (!authenticated && connected) {
+      clearExternalWallet();
+    }
+  }, [authenticated, stellarAddress, setExternalWallet, clearExternalWallet, connected]);
+
+  return null;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import './index.css';
 import { applyTheme, getPreferredTheme } from './lib/theme';
 import { LanguageProvider } from './i18n/I18nProvider';
 import { config } from './config';
+import PrivyWalletBridge from './components/Auth/PrivyWalletBridge';
 
 applyTheme(getPreferredTheme());
 
@@ -66,6 +67,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       // Privy dashboard — without credentials those buttons 403 in production.
       config={{ loginMethods: ['google', 'email'] }}
     >
+      <PrivyWalletBridge />
       {inner}
     </PrivyProvider>
   ) : inner


### PR DESCRIPTION
## Summary
- The Privy <-> wallet-store bridge only lived inside PrivyLogin, which is unmounted everywhere except /login. Signing out from any dashboard page left Privy logged out internally while the wallet store still reported connected, so the UI never reflected the sign-out.
- Moved the bridge into its own component (PrivyWalletBridge) mounted once at the app root, so it stays in sync regardless of route. PrivyLogin is now just the sign-in/sign-out button.

## Test plan
- [ ] Sign in, navigate to any dashboard page, click Disconnect -> immediately redirected to /login and wallet state is cleared
- [ ] Sign back in -> wallet reconnects normally