### PR TITLE
Fix invoices expiring on arrival and never crediting late payments

### DIFF
--- a/backend/src/services/watcherService.ts
+++ b/backend/src/services/watcherService.ts
@@ -5,6 +5,13 @@ import { log } from '../utils/logger';
 import { offRampService } from './offRampService';
 import { invoiceService } from './invoiceService';
 
+// A crypto payment that lands on-chain shortly after an invoice flips to
+// EXPIRED (e.g. a slower mobile wallet losing the race against the poll
+// cycle) should still be reconciled — the merchant did receive the funds.
+// This grace window keeps recently-expired crypto invoices in the scan
+// instead of ignoring them forever the moment they expire.
+const RECENTLY_EXPIRED_GRACE_MS = 24 * 60 * 60 * 1000; // 24h
+
 /**
  * WatcherService monitors the Stellar network for incoming payments
  * and matches them to pending invoices using transaction memos.
@@ -68,12 +75,22 @@ export class WatcherService {
   }
 
   /**
-   * Check all pending/processing/awaiting-payment invoices for on-chain payments
+   * Check all pending/processing/awaiting-payment invoices for on-chain payments.
+   * Also re-checks crypto invoices that expired within the grace window, so a
+   * payment that lands late (e.g. a slower mobile wallet) still gets credited
+   * instead of being ignored forever the instant status flips to EXPIRED.
    */
   async checkPendingInvoices() {
     const pendingInvoices = await prisma.invoice.findMany({
       where: {
-        status: { in: ['PENDING', 'PROCESSING', 'AWAITING_PAYMENT', 'SETTLING'] },
+        OR: [
+          { status: { in: ['PENDING', 'PROCESSING', 'AWAITING_PAYMENT', 'SETTLING'] } },
+          {
+            status: 'EXPIRED',
+            payoutMethod: { not: 'BRE_B' },
+            dueDate: { gt: new Date(Date.now() - RECENTLY_EXPIRED_GRACE_MS) },
+          },
+        ],
       },
       select: {
         id: true,

--- a/frontend/src/components/Invoice/InvoiceForm.tsx
+++ b/frontend/src/components/Invoice/InvoiceForm.tsx
@@ -12,6 +12,7 @@ import KycGate from '../Kyc/KycGate';
 import ComingSoonWall from '../Offramp/ComingSoonWall';
 import { railByCountry, FIAT_RAILS } from '../../config/rails';
 import { config } from '../../config';
+import { endOfDayIso } from '../../lib/format';
 import type { Currency, InvoiceType } from '../../types';
 import type { Language } from '../../i18n/translations';
 import usdcLogo from '../../assets/logos/usdc.png';
@@ -746,7 +747,7 @@ export default function InvoiceForm({ invoiceType = 'DIRECT_PAYMENT' }: Props) {
           payoutMethod: fiatSelected && fiatLive ? 'BRE_B' : 'CRYPTO',
           payoutAlias: fiatSelected && fiatLive ? payoutAlias.trim() || undefined : undefined,
           taxRate: taxRate ? parseFloat(taxRate) : undefined,
-          dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
+          dueDate: dueDate ? endOfDayIso(dueDate) : undefined,
           networkPassphrase,
           invoiceType,
           isOpenAmount: openAmount || undefined,

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -19,3 +19,19 @@ export function shortenAddress(value: string, head = 6, tail = 4): string {
   if (value.length <= head + tail) return value;
   return `${value.slice(0, head)}...${value.slice(-tail)}`;
 }
+
+/**
+ * Convert a date-only value (from `<input type="date">`, e.g. "2026-07-05")
+ * into an end-of-day UTC ISO string, so a due date means "through the end of
+ * the chosen day" instead of "the instant that day starts in UTC".
+ *
+ * `new Date("2026-07-05")` parses as UTC midnight — for anyone west of UTC
+ * (most of the Americas), that instant has already passed by the time they
+ * finish creating the invoice, so it expires on arrival. Anchoring to
+ * end-of-day UTC instead gives the full chosen day everywhere except deep
+ * into UTC+ timezones, which is the safest default without a stored
+ * per-merchant timezone.
+ */
+export function endOfDayIso(dateOnly: string): string {
+  return new Date(`${dateOnly}T23:59:59.999Z`).toISOString();
+}


### PR DESCRIPTION
## Summary
- Due date inputs are date-only, and converting them with new Date(str).toISOString() parsed as UTC midnight — for anyone west of UTC (e.g. Colombia, Costa Rica), that instant is already in the past by the time the invoice finishes being created, so it expires immediately regardless of payment method or wallet speed. Now anchored to end-of-day UTC instead.
- Once an invoice flipped to EXPIRED, the watcher stopped checking it forever. A payment that landed on-chain slightly late (e.g. a slower mobile wallet losing the race against the 5s poll cycle) was never reconciled even though the funds arrived. Crypto invoices expired within the last 24h are now re-checked and still marked paid if a matching payment is found.

## Test plan
- [ ] Create a Direct Payment link with today as the due date -> dueDate is end of day, not already expired
- [ ] Pay a link via a slower wallet (mobile/WalletConnect) that takes longer than 5s -> still marked PAID even if it crosses the due date
- [ ] Existing already-expired invoices from before this fix remain EXPIRED (grace window only covers the last 24h)